### PR TITLE
fix(inputs): Make sky a required input

### DIFF
--- a/pollination/point_in_time_grid/entry.py
+++ b/pollination/point_in_time_grid/entry.py
@@ -26,7 +26,6 @@ class PointInTimeGridEntryPoint(DAG):
     )
 
     sky = Inputs.str(
-        default='cie 21 Jun 12:00 -lat 0 -lon 0 -tz 0 -type 0',
         description='Sky string for any type of sky (cie, climate-based, irradiance, '
         'illuminance). This can be a minimal representation of the sky through '
         'altitude and azimuth (eg. "cie -alt 71.6 -az 185.2 -type 0"). Or it can be '


### PR DESCRIPTION
Users should always be plugging something in here and I only had a default as a means to give an example of what to input. But I think the input description takes care of this.